### PR TITLE
Feature/no tls listener

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: auto_release
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "feature/no-tls-listener" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
           git config --local user.name "arloor"
           # git tag  -f v1.0.0 -m 'latest'
           # git push --force origin v1.0.0
-          gh release create v1.0.0 target/release/rust_http_proxy_gnu target/release/rust_http_proxy_musl --notes-from-tag --latest -t latest  --target master
+          gh release create v1.0.0 target/release/rust_http_proxy_gnu target/release/rust_http_proxy_musl -n "latest" --latest -t latest  --target master
       - name: push
         run: |
           podman build  -f Dockerfile . -t docker.io/arloor/rust_http_proxy:${{ steps.vars.outputs.sha_short }} -t docker.io/arloor/rust_http_proxy:latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,9 +42,9 @@ jobs:
           fi
           git config --local user.email "admin@arloor.com"
           git config --local user.name "arloor"
-          git tag  -f v1.0.0 -m 'latest'
-          git push --force origin v1.0.0
-          gh release create v1.0.0 target/release/rust_http_proxy_gnu target/release/rust_http_proxy_musl --notes-from-tag --latest -t latest 
+          # git tag  -f v1.0.0 -m 'latest'
+          # git push --force origin v1.0.0
+          gh release create v1.0.0 target/release/rust_http_proxy_gnu target/release/rust_http_proxy_musl --notes-from-tag --latest -t latest  --target master
       - name: push
         run: |
           podman build  -f Dockerfile . -t docker.io/arloor/rust_http_proxy:${{ steps.vars.outputs.sha_short }} -t docker.io/arloor/rust_http_proxy:latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: auto_release
 
 on:
   push:
-    branches: [ "master","feature/low-level","feature/low-level-timed","tmp_hyper1" ]
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             "preLaunchTask": "rust: cargo build",
             "env": {
                 "port": "8888",
-                // "over_tls":"true",
+                "over_tls":"true",
                 "cert": "./cert.pem",
                 "raw_key": "./privkey.pem",
                 "refer": "arloor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,6 @@ dependencies = [
  "prometheus-client",
  "rand",
  "rustls-pemfile",
- "tls-listener",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -874,19 +873,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tls-listener"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e516b94ec383622ae4da09b2a9bab471c4c880453c93fd0dd4dff1f6f2ff0849"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "thiserror",
- "tokio",
- "tokio-rustls",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ mime_guess = "2.0"
 httpdate = "1.0"
 percent-encoding = "2.2"
 chrono = "0.4"
-tls-listener = { version = "0.9", features = ["rustls"] }
+# tls-listener = { version = "0.9", features = ["rustls"] }
 pin-project-lite = "0.2"
 prometheus-client = "0.22"

--- a/README.md
+++ b/README.md
@@ -146,4 +146,5 @@ Nginx收到的消息：
 - [tls-listener example](https://github.com/tmccombs/tls-listener/blob/main/examples/http.rs)
 - [tls-listener change-certificate](https://github.com/tmccombs/tls-listener/blob/main/examples/http-change-certificate.rs)
 - [hyper example http_proxy](https://github.com/hyperium/hyper/blob/master/examples/http_proxy.rs)
-- [async io trait impl for TlsStream](https://github.com/rustls/hyper-rustls/blob/286e1fa57ff5cac99994fab355f91c3454d6d83d/src/acceptor.rs)
+- [rustls async Acceptor for hyper v0.14](https://github.com/rustls/hyper-rustls/blob/286e1fa57ff5cac99994fab355f91c3454d6d83d/src/acceptor.rs)
+- [rustls async Acceptor for hyper v1](https://github.com/Gelbpunkt/hyper-rustls/blob/3d88d7d76c2e91e39b028dbbb92db917aa051092/src/acceptor.rs)

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -23,6 +23,12 @@ impl TlsAcceptor {
     pub fn new(config: Arc<ServerConfig>, listener: TcpListener) -> Self {
         Self { config, listener }
     }
+        /// Replaces the Tls Acceptor configuration, which will be used for new connections.
+    ///
+    /// This can be used to change the certificate used at runtime.
+    pub fn replace_config(&mut self, new_config: Arc<ServerConfig>) {
+        self.config = new_config;
+    }
 
     /// Accepts a new connection.
     pub async fn accept(&mut self) -> Result<(TlsStream, SocketAddr), io::Error> {

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -6,9 +6,12 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use futures_util::ready;
-use tokio_rustls::rustls::{ServerConfig, ServerConnection};
-use tokio::{net::{TcpListener, TcpStream}, io::{AsyncRead, AsyncWrite,ReadBuf}};
-
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::{TcpListener, TcpStream},
+};
+use tokio_rustls::rustls::ServerConfig;
+use tokio_rustls::rustls::ServerConnection;
 
 /// A TLS acceptor that can be used with hyper servers.
 pub struct TlsAcceptor<L = TcpListener> {
@@ -18,12 +21,11 @@ pub struct TlsAcceptor<L = TcpListener> {
 
 /// An Acceptor for the `https` scheme.
 impl TlsAcceptor {
-
     /// Creates a new `TlsAcceptor` from a `ServerConfig` and a `TcpListener`.
     pub fn new(config: Arc<ServerConfig>, listener: TcpListener) -> Self {
         Self { config, listener }
     }
-        /// Replaces the Tls Acceptor configuration, which will be used for new connections.
+    /// Replaces the Tls Acceptor configuration, which will be used for new connections.
     ///
     /// This can be used to change the certificate used at runtime.
     pub fn replace_config(&mut self, new_config: Arc<ServerConfig>) {
@@ -33,10 +35,7 @@ impl TlsAcceptor {
     /// Accepts a new connection.
     pub async fn accept(&mut self) -> Result<(TlsStream, SocketAddr), io::Error> {
         let (sock, addr) = self.listener.accept().await?;
-        Ok((
-            TlsStream::new(sock, self.config.clone()),
-            addr,
-        ))
+        Ok((TlsStream::new(sock, self.config.clone()), addr))
     }
 }
 
@@ -68,7 +67,7 @@ impl<C: AsyncRead + AsyncWrite + Unpin> TlsStream<C> {
     /// Returns a reference to the underlying IO stream.
     ///
     /// This should always return `Some`, except if an error has already been yielded.
-    pub fn io(&self) -> Option<&C> {
+    pub fn _io(&self) -> Option<&C> {
         match &self.state {
             State::Handshaking(accept) => accept.get_ref(),
             State::Streaming(stream) => Some(stream.get_ref().0),
@@ -78,7 +77,7 @@ impl<C: AsyncRead + AsyncWrite + Unpin> TlsStream<C> {
     /// Returns a reference to the underlying [`rustls::ServerConnection'].
     ///
     /// This will start yielding `Some` only after the handshake has completed.
-    pub fn connection(&self) -> Option<&ServerConnection> {
+    pub fn _connection(&self) -> Option<&ServerConnection> {
         match &self.state {
             State::Handshaking(_) => None,
             State::Streaming(stream) => Some(stream.get_ref().1),

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -1,0 +1,146 @@
+use core::task::{Context, Poll};
+use std::future::Future;
+use std::io;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures_util::ready;
+use tokio_rustls::rustls::{ServerConfig, ServerConnection};
+use tokio::{net::{TcpListener, TcpStream}, io::{AsyncRead, AsyncWrite,ReadBuf}};
+
+
+/// A TLS acceptor that can be used with hyper servers.
+pub struct TlsAcceptor<L = TcpListener> {
+    config: Arc<ServerConfig>,
+    listener: L,
+}
+
+/// An Acceptor for the `https` scheme.
+impl TlsAcceptor {
+
+    /// Creates a new `TlsAcceptor` from a `ServerConfig` and a `TcpListener`.
+    pub fn new(config: Arc<ServerConfig>, listener: TcpListener) -> Self {
+        Self { config, listener }
+    }
+
+    /// Accepts a new connection.
+    pub async fn accept(&mut self) -> Result<(TlsStream, SocketAddr), io::Error> {
+        let (sock, addr) = self.listener.accept().await?;
+        Ok((
+            TlsStream::new(sock, self.config.clone()),
+            addr,
+        ))
+    }
+}
+
+impl<C, L> From<(C, L)> for TlsAcceptor
+where
+    C: Into<Arc<ServerConfig>>,
+    L: Into<TcpListener>,
+{
+    fn from((config, listener): (C, L)) -> Self {
+        Self::new(config.into(), listener.into())
+    }
+}
+
+/// A TLS stream constructed by a [`TlsAcceptor`].
+// tokio_rustls::server::TlsStream doesn't expose constructor methods,
+// so we have to TlsAcceptor::accept and handshake to have access to it
+// TlsStream implements AsyncRead/AsyncWrite by handshaking with tokio_rustls::Accept first
+pub struct TlsStream<C = TcpStream> {
+    state: State<C>,
+}
+
+impl<C: AsyncRead + AsyncWrite + Unpin> TlsStream<C> {
+    fn new(stream: C, config: Arc<ServerConfig>) -> Self {
+        let accept = tokio_rustls::TlsAcceptor::from(config).accept(stream);
+        Self {
+            state: State::Handshaking(accept),
+        }
+    }
+    /// Returns a reference to the underlying IO stream.
+    ///
+    /// This should always return `Some`, except if an error has already been yielded.
+    pub fn io(&self) -> Option<&C> {
+        match &self.state {
+            State::Handshaking(accept) => accept.get_ref(),
+            State::Streaming(stream) => Some(stream.get_ref().0),
+        }
+    }
+
+    /// Returns a reference to the underlying [`rustls::ServerConnection'].
+    ///
+    /// This will start yielding `Some` only after the handshake has completed.
+    pub fn connection(&self) -> Option<&ServerConnection> {
+        match &self.state {
+            State::Handshaking(_) => None,
+            State::Streaming(stream) => Some(stream.get_ref().1),
+        }
+    }
+}
+
+impl<C: AsyncRead + AsyncWrite + Unpin> AsyncRead for TlsStream<C> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut ReadBuf,
+    ) -> Poll<io::Result<()>> {
+        let pin = self.get_mut();
+        let accept = match &mut pin.state {
+            State::Handshaking(accept) => accept,
+            State::Streaming(stream) => return Pin::new(stream).poll_read(cx, buf),
+        };
+
+        let mut stream = match ready!(Pin::new(accept).poll(cx)) {
+            Ok(stream) => stream,
+            Err(err) => return Poll::Ready(Err(err)),
+        };
+
+        let result = Pin::new(&mut stream).poll_read(cx, buf);
+        pin.state = State::Streaming(stream);
+        result
+    }
+}
+
+impl<C: AsyncRead + AsyncWrite + Unpin> AsyncWrite for TlsStream<C> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let pin = self.get_mut();
+        let accept = match &mut pin.state {
+            State::Handshaking(accept) => accept,
+            State::Streaming(stream) => return Pin::new(stream).poll_write(cx, buf),
+        };
+
+        let mut stream = match ready!(Pin::new(accept).poll(cx)) {
+            Ok(stream) => stream,
+            Err(err) => return Poll::Ready(Err(err)),
+        };
+
+        let result = Pin::new(&mut stream).poll_write(cx, buf);
+        pin.state = State::Streaming(stream);
+        result
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut self.state {
+            State::Handshaking(_) => Poll::Ready(Ok(())),
+            State::Streaming(stream) => Pin::new(stream).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match &mut self.state {
+            State::Handshaking(_) => Poll::Ready(Ok(())),
+            State::Streaming(stream) => Pin::new(stream).poll_shutdown(cx),
+        }
+    }
+}
+
+enum State<C> {
+    Handshaking(tokio_rustls::Accept<C>),
+    Streaming(tokio_rustls::server::TlsStream<C>),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ async fn serve(config: &'static ProxyConfig) -> Result<(), Box<dyn std::error::E
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     let mut terminate_signal = signal(SignalKind::terminate())?;
     if config.over_tls {
-
+        info!("featured mine TlsAcceptor");
         let mut acceptor = TlsAcceptor::new(tls_helper::tls_config(&config.raw_key, &config.cert)?,
         TcpListener::bind(addr).await?);
         let mut rx = init_listener_config_refresh_task(config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 #![deny(warnings)]
 mod acceptor;
-#[allow(dead_code)]
 mod log_x;
 mod net_monitor;
 mod proxy;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,16 @@
-#![deny(warnings)]
+// #![deny(warnings)]
+#[allow(dead_code)]
 
 mod log_x;
 mod net_monitor;
 mod proxy;
 mod tls_helper;
 mod web_func;
+mod acceptor;
 
 use crate::log_x::init_log;
 use crate::tls_helper::rust_tls_acceptor;
+use acceptor::TlsAcceptor;
 use http_body_util::combinators::BoxBody;
 use hyper::body::Bytes;
 use hyper::server::conn::http1;

--- a/src/tls_helper.rs
+++ b/src/tls_helper.rs
@@ -6,7 +6,7 @@ use tokio_rustls::rustls::ServerConfig;
 // wrap error
 type Error = Box<dyn std::error::Error>;
 
-pub fn rust_tls_acceptor(key: &String, cert: &String) -> Result<tokio_rustls::TlsAcceptor, Error> {
+pub fn _rust_tls_acceptor(key: &String, cert: &String) -> Result<tokio_rustls::TlsAcceptor, Error> {
     return Ok(tls_config(key, cert)?.into());
 }
 


### PR DESCRIPTION
delete dependency on tls-listener
refer to [hyper-rustls migrate to hyper v1.0](https://github.com/Gelbpunkt/hyper-rustls/blob/3d88d7d76c2e91e39b028dbbb92db917aa051092/src/acceptor.rs)